### PR TITLE
Fix django 1.5 template issue

### DIFF
--- a/poll/templates/poll/poll.html
+++ b/poll/templates/poll/poll.html
@@ -4,8 +4,8 @@
 
 {% block poll_script %}
 <script type="text/javascript">
-	var vote_url = '{% url poll_ajax_vote poll.pk %}';
-	var result_url = '{% url poll_result poll.pk %}';
+	var vote_url = '{% url "poll_ajax_vote" poll.pk %}';
+	var result_url = '{% url "poll_result" poll.pk %}';
 	$(document).ready(function() {
 		function showResults() {
 			$.get(result_url, function(data) {


### PR DESCRIPTION
'url' requires a non-empty first argument. The syntax changed in Django
1.5, see the docs.
